### PR TITLE
Allowing RestfulObjects.Mvc package to accept newtonsoft.json 6.0.8 t…

### DIFF
--- a/RestfulObjects Server/RestfulObjects.Mvc.package/RestfulObjects.Mvc.nuspec
+++ b/RestfulObjects Server/RestfulObjects.Mvc.package/RestfulObjects.Mvc.nuspec
@@ -15,7 +15,7 @@
     <description>Typically this package is only installed as a dependency of another package.</description>
     <dependencies>
       <dependency id="NakedObjects.Facade" version="[1.0.0, 2)" />
-      <dependency id="Newtonsoft.Json" version="[6.0.8, 7.0)" />
+      <dependency id="Newtonsoft.Json" version="[6.0.8, 10.0.0)" />
       <dependency id="Microsoft.AspNet.WebApi" version="[5.2.3, 6.0)" />
     </dependencies>
     <frameworkAssemblies>


### PR DESCRIPTION
To avoid dependency convergence issues, we need to allow our application to use both mnof.restful.mvc and Newtonsoft.Converter 9.0.1 . 
This change makes both compatible